### PR TITLE
Add command variants

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,57 @@ const board = new five.Board();
 
 let strip;
 
+/**
+ * Returns a pixel index from the given arguments.
+ * Returns null if the index is not valid (e.g. < 0 or > 39).
+ * @param {string[]} args
+ */
+const getPixelIndex = (args) => {
+  const input = args.join(' ');
+  if (input.match(/^r /i)) return Math.floor(Math.random() * 40);
+  const fromIndex = input.match(/^index (\d+)/i);
+  const fromCoords = input.match(/^x (\d+) y (\d+)/i);
+  const fromRowCol = input.match(/^row (\d+) col (\d+)/i);
+  if (fromIndex) {
+    const index = parseInt(fromIndex[1]);
+    if (index < 0 || index > 39) return null;
+    return index;
+  }
+  if (fromCoords) {
+    const x = parseInt(fromCoords[1]);
+    const y = parseInt(fromCoords[2]);
+    if (x < 0 || x > 7) return null;
+    if (y < 0 || y > 4) return null;
+    return y * 8 + x;
+  }
+  if (fromRowCol) {
+    const row = parseInt(fromCoords[1]);
+    const col = parseInt(fromCoords[2]);
+    if (col < 0 || col > 7) return null;
+    if (row < 0 || row > 4) return null;
+    return row * 8 + col;
+  }
+  return null;
+};
+
+/**
+ * Returns a color from the given arguments.
+ * Returns null if the color is not valid.
+ * @param {string[]} args 
+ */
+const getColor = (args) => {
+  const input = args.join(' ');
+  if (input.match(/^r /i)) {
+    return ['r', 'g', 'b'].map(() => {
+      const hex = Math.floor(Math.random() * 256).toString(16);
+      return hex.length === 1 ? `0${hex}` : hex;
+    }).join();
+  }
+  const matches = input.match(/color ([0-9a-f]{6})$/i);
+  if (matches) return matches[1];
+  return null;
+};
+
 const validColor = (color) => color.match(/^[0-9a-f]{6}$/i);
 
 const lightenColor = (color) => {
@@ -49,17 +100,12 @@ board.on('ready', () => {
       if (message.startsWith('!')) {
         const args = message.split(' ');
         const command = args.shift();
-        // TODO: !pixel index 0 color 00FF00
-        // TODO: !pixel x 3 y 4 color 00FF00
-        // TODO: !pixel row 3 col 4 color 00FF00
-        // TODO: !pixel r
         if (command === '!pixel') {
           if (!args.length) return;
-          const pixelIndex = parseInt(args.shift(), 10);
-          if (isNaN(pixelIndex)) return;
-          if (pixelIndex < 0 || pixelIndex > 39) return;
-          const color = args.shift();
-          if (!color || !validColor(color)) return;
+          const pixelIndex = getPixelIndex(args);
+          if (!pixelIndex) return;
+          const color = getColor(args);
+          if (!color) return;
           const lightenedColor = lightenColor(color);
           strip.pixel(pixelIndex).color(lightenedColor);
           strip.show();

--- a/src/index.js
+++ b/src/index.js
@@ -53,15 +53,17 @@ const getPixelIndex = (args) => {
 /**
  * Returns a color from the given arguments.
  * Returns null if the color is not valid.
- * @param {string[]} args 
+ * @param {string[]} args
  */
 const getColor = (args) => {
   const input = args.join(' ');
   if (input.match(/^r /i)) {
-    return ['r', 'g', 'b'].map(() => {
-      const hex = Math.floor(Math.random() * 256).toString(16);
-      return hex.length === 1 ? `0${hex}` : hex;
-    }).join();
+    return ['r', 'g', 'b']
+      .map(() => {
+        const hex = Math.floor(Math.random() * 256).toString(16);
+        return hex.length === 1 ? `0${hex}` : hex;
+      })
+      .join();
   }
   const matches = input.match(/color ([0-9a-f]{6})$/i);
   if (matches) return matches[1];


### PR DESCRIPTION
Added support for the following command variants:
* `!pixel index 0 color 00FF00`
* `!pixel x 3 y 4 color 00FF00`
* `!pixel row 3 col 4 color 00FF00`
* `!pixel r`

The `!pixel r` command currently returns a random pixel index and a random color. I'm not certain if this is the intended behavior of the command but it can easily be changed to return the user's Twitch username color for example.

Note: I tested my code through my browser's console (Firefox) as I do not have an Arduino. My changes theoretically don't have an effect on the current implementation as the index and color outputs are in the same format. But still, you're welcome to test it before merging it into the master branch.

:) 
