### PR TITLE
Add support for !rgb command compression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,17 @@ let strip;
 
 const validColor = (color) => color.match(/^[0-9a-f]{6}$/i);
 
+function embiggen(command) {
+  command = command.split(/[ ,]/g)
+  command.shift()
+  let indices = [];
+  return command.map(color=>{
+    if (color.startsWith("*")) return indices[parseInt(color.slice(1), 16)]
+    indices.push(color);
+    return color;
+  })
+}
+
 const lightenColor = (color) => {
   const [h, s] = chroma(`#${color}`).hsl();
   return chroma.hsl(h, s, 0.3).hex();
@@ -66,7 +77,7 @@ board.on('ready', () => {
         } else if (command === '!rgb') {
           if (!args.length) return;
           const colorsString = args.shift();
-          const colors = colorsString.split(',');
+          const colors = embiggen(colorsString);
           if (colors.length !== 40) return;
           colors.forEach((color, i) => {
             if (validColor(color)) {


### PR DESCRIPTION
Added support to read compressed !rgb commands where the colours can be either a raw colour or an index of an existing colour.
i.e. if the first colour is red then the second green then the third red
`!rgb ff0000,00ff00,ff0000`
rather than repeat the red colour again we can use a back-reference.
`!rgb ff0000,00ff00,*0` meaning the third colour is the same as the first.

The `*` denotes a back reference.

Two upsides is that this still supports the old format for anyone who wants to write the raw command. And the compressed format will never be larger than the original even if no colour is repeated as it will just be the same as if we had not compressed it.

The mirrored pull-request on react-pixel-art-maker can be found [here](https://github.com/CodingGarden/react-pixel-art-maker/pull/6#issue-477979117)